### PR TITLE
modified quotes and apostrophe in docstring

### DIFF
--- a/filestorage/filestorage.py
+++ b/filestorage/filestorage.py
@@ -1,6 +1,6 @@
 """ 
-The “File Storage XBlock” allows course staffers to add files stored in various internet file storage services to the courseware (courseware, course info and syllabus) 
-by adding a link through an advanced component that they create in edX’s Studio authoring tool. The files can be added either as embedded content, 
+The "File Storage XBlock" allows course staffers to add files stored in various internet file storage services to the courseware (courseware, course info and syllabus) 
+by adding a link through an advanced component that they create in edX's Studio authoring tool. The files can be added either as embedded content, 
 or as links to the files in their original location.
 """ 
 


### PR DESCRIPTION
Starting up a Python shell on a production server with:

``` bash
python manage.py lms --settings=aws shell
```

And running:

``` python
from xmodule.modulestore.django import modulestore
mongo_courses = modulestore().get_courses()
```

Gave me this error:

```
2015-09-21 12:50:48,089 WARNING 24751 [xblock.plugin] plugin.py:138 - Unable to load XBlock 'filestorage'
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/plugin.py", line 136, in load_classes
    yield (class_.name, cls._load_class_entry_point(class_))
  File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/plugin.py", line 73, in _load_class_entry_point
    class_ = entry_point.load()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/pkg_resources.py", line 2087, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/edx/app/edxapp/xblocks/xblock-filestorage/filestorage/__init__.py", line 1, in <module>
    from .filestorage import FileStorageXBlock
  File "/edx/app/edxapp/xblocks/xblock-filestorage/filestorage/filestorage.py", line 2
SyntaxError: Non-ASCII character '\xe2' in file /edx/app/edxapp/xblocks/xblock-filestorage/filestorage/filestorage.py on line 3, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details
```

Removing those three non-ascii characters fixed the problem for me.
